### PR TITLE
Use custom layouts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,7 +9,7 @@ module.exports = function(eleventyConfig) {
     markdownTemplateEngine: 'njk',
     templateFormats: ['njk', 'md'],
     dir: {
-      layouts: './node_modules/govuk-eleventy-plugin/app/layouts',
+      layouts: '_layouts',
       // govukEleventyPlugin requires `output` to save compiled assets
       output: process.argv[3].split('=')[1] || '_site'
     }

--- a/_layouts/base.njk
+++ b/_layouts/base.njk
@@ -1,0 +1,47 @@
+{% extends "govuk/template.njk" %}
+
+{% block head %}
+  <link rel="stylesheet" href="/assets/govuk.css">
+{% endblock %}
+
+{% block pageTitle %}
+  {{- title if title -}}
+{% endblock %}
+
+{% block header %}
+  <header class="govuk-header" role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container app-header__container--pink">
+      <div class="govuk-header__logo">
+        <a href="/" class="govuk-header__link govuk-header__link--homepage">
+          X-GOVUK
+        </a>
+      </div>
+    </div>
+  </header>
+{% endblock %}
+
+{% block footer %}
+  <footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+      <div class="govuk-footer__meta">
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <ul class="govuk-footer__inline-list">
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="https://github.com/x-govuk/x-govuk.github.io">
+                GitHub source
+              </a>
+            </li>
+          </ul>
+          <div class="govuk-footer__meta-custom">
+            An unofficial community project
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+{% endblock %}
+
+{% block bodyEnd %}
+  <script src="/assets/govuk.js"></script>
+  {% block scripts %}{% endblock %}
+{% endblock %}

--- a/_layouts/product.njk
+++ b/_layouts/product.njk
@@ -1,0 +1,30 @@
+{% extends "_layouts/base.njk" %}
+
+{% from "x-govuk/components/masthead/macro.njk" import xGovukMasthead %}
+
+{% block main %}
+  {{ xGovukMasthead({
+    classes: "x-govuk-masthead--large",
+    title: {
+      html: title
+    } if title,
+    description: {
+      html: description | markdown("inline") | noOrphans
+    } if description,
+    startButton: startButton,
+    image: image,
+    breadcrumbs: {
+      classes: "govuk-!-display-none-print",
+      items: collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: true }) | items
+    } if eleventyNavigation.parent
+  }) }}
+
+  <div class="govuk-width-container">
+    {% block beforeContent %}{% endblock %}
+    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+    </main>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This switches to using custom layouts, rather than the ones provided by the `govuk-eleventy-plugin` plugin.

This is mainly so that the header can be customised to remove the crown and `GOV.UK`, and the footer can be simplified (for now).