### PR TITLE
Override the pageTitle

### DIFF
--- a/_layouts/product.njk
+++ b/_layouts/product.njk
@@ -1,5 +1,11 @@
 {% extends "app/layouts/product.njk" %}
 
+{% block pageTitle %}
+  {{- title if title -}}
+  {{- " (page " + pageNumber + " of " + pageCount + ")" if pageCount > 1 -}}
+  {{- " - X-GOVUK" -}}
+{% endblock %}
+
 {% block footer %}
   <footer class="govuk-footer" role="contentinfo">
     <div class="govuk-width-container">


### PR DESCRIPTION
Need to override this, as the project isn't an official GOV.UK one so shouldn't have `- GOV.UK` in the page title.

Also a workaround for this issue: https://github.com/x-govuk/govuk-eleventy-plugin/issues/11