### PR TITLE
Rearrange index page

### DIFF
--- a/app/includes/posts.njk
+++ b/app/includes/posts.njk
@@ -1,6 +1,5 @@
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
-<h2 class="govuk-heading-l govuk-!-margin-bottom-1" id="posts">Posts</h2>
-<p class="govuk-body-l app-!-colour-muted">Notes and updates on projects being developed across government teams</p>
+<h2 class="govuk-heading-l" id="posts">Posts</h2>
 <div class="govuk-grid-row">
 {% set columns = cycler("1", "2") %}
 {% for post in collections.post | reverse %}

--- a/app/includes/shared_projects.njk
+++ b/app/includes/shared_projects.njk
@@ -13,7 +13,7 @@
   {% endif %}
 {% endfor %}
   {# Add this project manually as hosted on Heroku #}
-  <section class="govuk-grid-column-one-half-from-desktop govuk-!-margin-bottom-8">
+  <section class="govuk-grid-column-one-half-from-desktop govuk-!-margin-bottom-4">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
       <a class="govuk-link" href="https://govuk-digital-services.herokuapp.com">UK Government digital services</a>
     </h3>

--- a/app/includes/shared_projects.njk
+++ b/app/includes/shared_projects.njk
@@ -1,6 +1,4 @@
-<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
-<h2 class="govuk-heading-l govuk-!-margin-bottom-1" id="shared-projects">Shared projects</h2>
-<p class="govuk-body-l app-!-colour-muted">Collaborative projects in active development</p>
+<h2 class="govuk-heading-l" id="projects">Projects</h2>
 <div class="govuk-grid-row">
 {% set columns = cycler("1", "2") %}
 {% for repo in repos %}

--- a/app/index.md
+++ b/app/index.md
@@ -4,6 +4,13 @@ homepage: true
 title: Welcome to X-GOVUK
 description: A community-maintained collection of resources which are useful for working on GOV.UK services.
 ---
+
+{% include "../app/includes/shared_projects.njk" %}
+
+{% include "../app/includes/posts.njk" %}
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl govuk-!-margin-top-0">
+
 <h2 class="govuk-heading-l" id="resources">Resources</h2>
 
 <div class="govuk-grid-row">
@@ -75,7 +82,3 @@ description: A community-maintained collection of resources which are useful for
 </div>
 
 <p class="govuk-body-s govuk-!-margin-bottom-8"><a class="govuk-link" href="https://github.com/{{ pkg.repository.url | replace(".git", "") }}/blob/main/{{ page.inputPath | replace("./", "") }}">Edit this list on GitHub</a></p>
-
-{% include "../app/includes/shared_projects.njk" %}
-
-{% include "../app/includes/posts.njk" %}


### PR DESCRIPTION
- Put x-govuk specific projects and posts first
- Move long list of resources to the bottom
- Remove tag line from each section, posts and projects each have their own description and collaboration context is set by the website tagline

| Before | After |
|--|--|
| ![x-govuk github io_](https://user-images.githubusercontent.com/319055/165770840-f775f933-81d1-474b-965e-a5d5ae27771d.png) | ![localhost_8081_ (2)](https://user-images.githubusercontent.com/319055/165771718-e486a967-db65-491e-a2e7-0eb3ed6e1374.png) |