### PR TITLE
Bugfix: link to "Edit this list on GitHub"

### DIFF
--- a/app/index.md
+++ b/app/index.md
@@ -81,4 +81,4 @@ description: A community-maintained collection of resources which are useful for
 </div>
 </div>
 
-<p class="govuk-body-s govuk-!-margin-bottom-8"><a class="govuk-link" href="https://github.com/{{ pkg.repository.url | replace(".git", "") }}/blob/main/{{ page.inputPath | replace("./", "") }}">Edit this list on GitHub</a></p>
+<p class="govuk-body-s govuk-!-margin-bottom-8"><a class="govuk-link" href="{{ pkg.repository.url | replace("io.git", "io") }}/blob/main/{{ page.inputPath | replace("./", "") }}">Edit this list on GitHub</a></p>


### PR DESCRIPTION
The domain part (https://github.com/) isn't needed, and `replace(".git", "")` was over-matching on other parts of the string.

Sadly the built-in nunjucks `replace()` filter doesn't support regex, and there's no "drop last n characters" filter, so I've bodged it for now...