### PR TITLE
Update links to design history resources

### DIFF
--- a/app/includes/shared_projects.njk
+++ b/app/includes/shared_projects.njk
@@ -15,7 +15,7 @@
   {# Add this project manually as hosted on Heroku #}
   <section class="govuk-grid-column-one-half-from-desktop govuk-!-margin-bottom-4">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="https://govuk-digital-services.herokuapp.com">GOV.UK services list</a>
+      <a class="govuk-link" href="https://govuk-digital-services.herokuapp.com">GOV.UK Services list</a>
     </h3>
     <p class="govuk-body">A catalogue of digital services from the UK government and its agencies.</p>
   </section>

--- a/app/index.md
+++ b/app/index.md
@@ -43,7 +43,6 @@ description: A community-maintained collection of resources which are useful for
 
 #### Other design resources
 
-* [GOV.UK Design histories](https://github.com/x-govuk/govuk-design-history)
 * [Statistics on usage of `govuk-frontend` components](https://github.com/x-govuk/govuk-frontend-component-stats)
 
 ### User research

--- a/app/posts/govuk-eleventy-plugin.md
+++ b/app/posts/govuk-eleventy-plugin.md
@@ -15,13 +15,13 @@ opengraphImage:
   alt: Examples of customised websites using the plugin.
 ---
 
-Back in 2018, the Becoming a teacher team at the Department for Education wanted to [document the design evolution of the services they were building](https://design-history.herokuapp.com/keeping-a-design-history/). A small website was built using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs), but this soon became difficult to manage as more people joined the team and wanted to write posts.
+Back in 2018, the Becoming a teacher team at the Department for Education wanted to [document the design evolution of the services they were building](https://x-govuk.github.io/govuk-design-history-docs/case-study/). A small website was built using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs), but this soon became difficult to manage as more people joined the team and wanted to write posts.
 
 Looking for alternatives, the team chose [Eleventy](https://11ty.dev), a static website generator developed by Zach Leatherman[^1]. Like the Prototype Kit, it uses Node.js, yet is designed around organising and publishing content-focused websites.
 
 This includes support for [Markdown](https://www.markdownguide.org), a lightweight markup language for formatting plain text documents. Posts can incorporate metadata like publication dates and authors, and be organised into different collections.
 
-With this foundation in place, [the design history](https://bat-design-history.netlify.app/) grew to over 500 posts written by more than 20 authors. In 2020 we made this tool available as [a template repository on GitHub](https://github.com/x-govuk/govuk-design-history) so that other teams could quickly begin writing their own design histories. The tool has since been adopted by other teams, both inside the Department for Education and across government.
+With this foundation in place, [the design history](https://bat-design-history.netlify.app/) grew to over 500 posts written by more than 20 authors. In 2020 we made this tool available as [a template repository on GitHub](https://github.com/x-govuk/govuk-design-history-template) so that other teams could quickly begin writing their own design histories. The tool has since been adopted by other teams, both inside the Department for Education and across government.
 
 However, as the number of websites using this template has grown, the harder it has become to share improvements. Abstracting the common parts into an npm module makes it easier for us to do this.
 

--- a/app/posts/introduction.md
+++ b/app/posts/introduction.md
@@ -28,7 +28,7 @@ The "X" also stands for "experimental", as this can be a space for ideas that ar
 
 Projects include:
 
-* a [template for writing design histories](https://github.com/x-govuk/govuk-design-history)
+* a [template for writing design histories](https://github.com/x-govuk/govuk-design-history-template)
 * a [crowdsourced list of UK government digital services](https://govuk-digital-services.herokuapp.com)
 * an [extension for the GOV.UK Prototype Kit to enable forking questions based on radios](https://github.com/x-govuk/prototype-navigation-radios)
 * a [wizard tool](https://github.com/x-govuk/govuk-prototype-wizard) for building and iterating 'one thing per page' user journeys in prototypes


### PR DESCRIPTION
* Homepage:
  * Remove link to ‘GOV.UK Design histories’ in list as project now appears in ‘Shared projects’
  * Use same capitalisation for ‘Services list’ as that project’s website
* Update links to relevant resources in blog posts