### PR TITLE
Prevent display of incorrect tags field

### DIFF
--- a/app/posts/contributing-to-govuk-design-system.md
+++ b/app/posts/contributing-to-govuk-design-system.md
@@ -2,7 +2,6 @@
 title: Why I contribute to the GOV.UK Design System (and why you should too)
 description: How I helped to publish a pattern for confirming a phone number, and ways in which you can contribute to the GOV.UK Design System too.
 date: 2022-04-07
-tags: post
 layout: post
 author:
   name: Frankie Roberto

--- a/app/posts/contributing-to-govuk-design-system.md
+++ b/app/posts/contributing-to-govuk-design-system.md
@@ -2,7 +2,6 @@
 title: Why I contribute to the GOV.UK Design System (and why you should too)
 description: How I helped to publish a pattern for confirming a phone number, and ways in which you can contribute to the GOV.UK Design System too.
 date: 2022-04-07
-layout: post
 author:
   name: Frankie Roberto
   url: https://github.com/frankieroberto

--- a/app/posts/govuk-eleventy-plugin.md
+++ b/app/posts/govuk-eleventy-plugin.md
@@ -2,7 +2,6 @@
 title: Write documentation using Markdown and publish it using GOV.UK styles
 description: The GOV.UK Eleventy Plugin makes it easy to start writing documentation rather than spend time building a website for it.
 date: 2022-04-04
-tags: post
 layout: post
 author:
   name: Paul Lloyd

--- a/app/posts/govuk-eleventy-plugin.md
+++ b/app/posts/govuk-eleventy-plugin.md
@@ -2,7 +2,6 @@
 title: Write documentation using Markdown and publish it using GOV.UK styles
 description: The GOV.UK Eleventy Plugin makes it easy to start writing documentation rather than spend time building a website for it.
 date: 2022-04-04
-layout: post
 author:
   name: Paul Lloyd
   url: https://github.com/paulrobertlloyd

--- a/app/posts/introduction.md
+++ b/app/posts/introduction.md
@@ -2,7 +2,6 @@
 title: An introduction to X-GOVUK
 description: What the "X" in "X-GOVUK" stands for.
 date: 2022-03-16
-tags: post
 layout: post
 authors:
   - name: Frankie Roberto

--- a/app/posts/introduction.md
+++ b/app/posts/introduction.md
@@ -2,7 +2,6 @@
 title: An introduction to X-GOVUK
 description: What the "X" in "X-GOVUK" stands for.
 date: 2022-03-16
-layout: post
 authors:
   - name: Frankie Roberto
     url: https://github.com/frankieroberto

--- a/app/posts/maintaining-a-list-of-govuk-services.md
+++ b/app/posts/maintaining-a-list-of-govuk-services.md
@@ -2,7 +2,6 @@
 title: Maintaining a list of GOV.UK services
 description: Why the community has built a list of over 400 digital UK government services, including links to source code and service assessments, and how you can contribute.
 date: 2023-03-20
-tags: post
 layout: post
 author:
   name: Frankie Roberto

--- a/app/posts/maintaining-a-list-of-govuk-services.md
+++ b/app/posts/maintaining-a-list-of-govuk-services.md
@@ -2,7 +2,6 @@
 title: Maintaining a list of GOV.UK services
 description: Why the community has built a list of over 400 digital UK government services, including links to source code and service assessments, and how you can contribute.
 date: 2023-03-20
-layout: post
 author:
   name: Frankie Roberto
   url: https://github.com/frankieroberto

--- a/app/posts/posts.json
+++ b/app/posts/posts.json
@@ -1,4 +1,5 @@
 {
+  "layout": "post",
   "eleventyNavigation": {
     "parent": "Posts"
   }

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -31,6 +31,11 @@ module.exports = function (eleventyConfig) {
     }
   })
 
+  // Collections
+  eleventyConfig.addCollection('post', collection => {
+    return collection.getFilteredByGlob('app/posts/*.md')
+  })
+
   // Pass through
   eleventyConfig.addPassthroughCopy('./app/assets')
 


### PR DESCRIPTION
Relates to https://github.com/x-govuk/govuk-eleventy-plugin/issues/157

Currently the posts listing shows a ‘post’ tag:

<img width="460" alt="Screenshot 2023-05-21 at 15 07 19" src="https://github.com/x-govuk/x-govuk.github.io/assets/813383/7eb80d23-5b79-46eb-91d4-17f35f8d593e">

And post pages show an empty tags field:

<img width="380" alt="Screenshot 2023-05-21 at 15 07 28" src="https://github.com/x-govuk/x-govuk.github.io/assets/813383/0455f6ec-6e2c-4610-b5e1-9d54ba488fec">

By creating the collection in via the config file, using the `addCollection` API method, we can prevent this from happening.

Also, while I’m here, set the default layout to `post` for files in the `posts` folder.