### PR TITLE
Specify Node version 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Build with Eleventy


### PR DESCRIPTION
We were building the site with Node 18 (GitHub's current default), resulting in this warning:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'x-govuk@1.0.0',
npm WARN EBADENGINE   required: { node: '^20.0.0' },
npm WARN EBADENGINE   current: { node: 'v18.20.2', npm: '10.5.0' }
npm WARN EBADENGINE }
```

Possibly there’s a way to configure `npm ci` to throw an exception rather than a warning in case of an engine mis-match? Would've caught this.